### PR TITLE
Cert fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,15 @@
+Tequila-nginx
+=============
+
+Changes
+
+v 0.8.2 on Sep 6, 2017
+----------------------
+
+* Provide a 'none' cert_source option (fixes #7)
+
+* Start nginx a bit later (fixes #6)
+
+* Add assertions about the cert_source (fixes #5)
+
+* Use the proper X-Forwarded-Proto header

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ role:
 - ``auth_file`` **default:** ``"{{ root_dir }}/.htpasswd"``
 - ``dhparams_file`` **default:** ``"{{ ssl_dir }}/dhparams.pem"``
 - ``dhparams_numbits`` **default:** ``2048``
-- ``cert_source`` **required, values:** ``'letsencrypt'``, ``'selfsign'``, ``'provided'``
+- ``cert_source`` **required, values:** ``'none'``, ``'letsencrypt'``, ``'selfsign'``, ``'provided'``
 - ``admin_email`` **required if cert_source = letsencrypt**
 - ``ssl_cert`` **required if cert_source = provided**
 - ``ssl_key`` **required if cert_source = provided**

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,10 +6,6 @@
   apt: name=nginx
        state=latest
 
-- name: start nginx
-  service: name=nginx
-           state=started
-
 - name: remove_existing_conf
   file: path=/etc/nginx/sites-enabled/default
         state=absent
@@ -90,6 +86,10 @@
     mode=644
     src={{ nginx_conf_template|default('nginx.conf.j2') }}
   notify: reload nginx
+
+- name: start nginx
+  service: name=nginx
+           state=started
 
 - include: letsencrypt.yml
   when: cert_source == "letsencrypt"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,12 @@
     creates: "{{ dhparams_file }}"
   when: env_name != 'local'
 
+- name: require a valid choice for the SSL certificate
+  assert: { that: "cert_source in ('none', 'letsencrypt', 'selfsign', 'provided')" }
+
+- name: do not allow force_ssl if the cert_source is none
+  assert: { that: "cert_source != 'none' or not force_ssl" }
+
 - name: optionally generate self-signed cert
   command: "{{ item }}"
   args:

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -80,6 +80,7 @@ server {
     {% endif %}
 }
 
+{% if cert_source != 'none' %}
 server {
     listen 443;
     server_name {{ domain }};
@@ -106,3 +107,4 @@ server {
 
     {{ serve_django() }}
 }
+{% endif %}


### PR DESCRIPTION
* Provide a 'none' cert_source option (fixes #7)
* Start nginx a bit later (fixes #6)
* Add assertions about the cert_source (fixes #5)
