### PR TITLE
[TEQ-72] Override nginx ports and don't add invalid header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Tequila-nginx
 Changes
 
 
-v X.Y.Z on MMM dd, YYYY
+v 0.8.8 on Jul 30, 2018
 -----------------------
 
 * New variable ``project_port`` to say that Django is listening on a port

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Tequila-nginx
 Changes
 
 
+v 0.8.9 on Sep 11, 2018
+-----------------------
+
+* New variables ``nginx_http_port`` and ``nginx_https_port`` to
+  override the listen ports from 80 and 443.
+
 v 0.8.8 on Jul 30, 2018
 -----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,12 @@ role:
 - ``letsencrypt_domains`` **default:** ``[domain, 'www.'+domain]``
 - ``use_memcached`` **default:** ``true``
 - ``app_minions`` **required:** combined list of web servers and celery worker servers
+- ``nginx_http_port`` **default:** ``80``
+  Override the port nginx listens on without SSL. Can be used if a load balancer
+  is listening on port 80.
+- ``nginx_https_port`` **default:** ``443``
+  Override the port nginx listens on with SSL. Can be used if a load balancer
+  is listening on port 443.
 
 The ``app_minions`` variable can be constructed from Ansible's
 inventory information, like ::

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,5 @@ dhparams_file: "{{ ssl_dir }}/dhparams.pem"
 http_auth: []
 auth_file: "{{ root_dir }}/.htpasswd"
 use_memcached: true
+nginx_http_port: 80
+nginx_https_port: 443

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -96,7 +96,7 @@ server {
 
 {% if cert_source != 'none' %}
 server {
-    listen {{ nginx_https_port }} ssl;
+    listen {{ nginx_https_port }};
     server_name {{ domain_list | join(' ') }};
 
     access_log syslog:server=unix:/dev/log;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -55,16 +55,12 @@ upstream {{ project_name }}  {
         auth_basic "Restricted";
         auth_basic_user_file {{ auth_file }};
         {% endif %}
+
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        # The proper header is "X-Forwarded-Proto", not "X-Forwarded-Protocol".
-        # But we've been setting X-Forwarded-Protocol for years, so we might
-        # have projects that are using it. New projects should NOT use it.
-        # Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
-        proxy_set_header X-Forwarded-Protocol $scheme;
-        # Here's the proper header:
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
+
         proxy_redirect off;
         proxy_buffering on;
         proxy_intercept_errors on;
@@ -76,7 +72,7 @@ upstream {{ project_name }}  {
 {%- endmacro %}
 
 server {
-    listen 80;
+    listen {{ nginx_http_port }};
     server_name {{ domain_list | join(' ') }};
 
     access_log syslog:server=unix:/dev/log;
@@ -100,7 +96,7 @@ server {
 
 {% if cert_source != 'none' %}
 server {
-    listen 443;
+    listen {{ nginx_https_port }} ssl;
     server_name {{ domain_list | join(' ') }};
 
     access_log syslog:server=unix:/dev/log;


### PR DESCRIPTION
* Let user configure the port numbers that nginx listens on for the
  project.
* Adding the (always invalid) header "X-Forwarded-Protocol" when
  proxying was resulting in 400 errors for me. I hope it's been long
  enough that we can just remove this from the configuration.

(When I'm running haproxy or another load balancer on the same server as my web server, the LB and nginx can't both listen on ports 80 and 443. Provide a way to override the ports nginx listens on for http and https, while leaving the default at 80 and 443.)