### PR TITLE
Check X-Forwareded-Proto even on port 443

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Tequila-nginx
 Changes
 
 
+v 0.8.10 on Sep 6, 2019
+-----------------------
+
+* If nginx is behind a load balancer that sets X-Forwarded-Proto: http,
+  redirect to HTTPS even on port 443.
+
 v 0.8.9 on Sep 11, 2018
 -----------------------
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -117,6 +117,10 @@ server {
 
     {% if force_ssl %}
     add_header Strict-Transport-Security max-age=31536000;
+    {# if there is a forwarded proto value and it's set to 'http' (i.e., if we're sitting behind another load balancer that is forwarding its port 80 to our port 443), redirect #}
+    if ($http_x_forwarded_proto = 'http') {
+        return 301 https://$host$request_uri;
+    }
     {% endif %}
 
     {{ serve_django() }}


### PR DESCRIPTION
If nginx is behind a load balancer that sets `X-Forwarded-Proto: http`, redirect to HTTPS even on port 443.