### PR TITLE
don't add an extra trailing slash when redirecting

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -8,7 +8,7 @@ upstream {{ project_name }}  {
 
     {% if redirect_domains|default([]) %}
     if ($host ~* ^({{ redirect_domains | default([]) | join('|') }})$) {
-        return 301 $scheme://{{ domain }}/$request_uri;
+        return 301 $scheme://{{ domain }}$request_uri;
     }
     {% endif %}
 


### PR DESCRIPTION
**EDIT:** Just discovered #18 , we might want to do that instead (it includes this fix, and another maybe).

It looks like $request_uri includes a leading slash, because setting `redirect_domains` is giving me a double trailing slash on the redirected domain.

Before:
```
$ curl -I https://redirectdomain.com
HTTP/1.1 301 Moved Permanently
Content-Type: text/html
Date: Wed, 25 Sep 2019 21:17:21 GMT
Location: https://realdomain.com//
Server: nginx/1.16.1
Strict-Transport-Security: max-age=31536000
Content-Length: 169
Connection: keep-alive
```

After:
```
$ curl -I https://redirectdomain.com
HTTP/1.1 301 Moved Permanently
Content-Type: text/html
Date: Wed, 25 Sep 2019 21:18:40 GMT
Location: https://realdomain.com/
Server: nginx/1.16.1
Strict-Transport-Security: max-age=31536000
Content-Length: 169
Connection: keep-alive
```