### PR TITLE
Fix Ansible deprecations with httpauth tasks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,17 @@ Tequila-nginx
 
 Changes
 
+v 0.8.12 on Sep 30, 2019
+------------------------
+
+* Fix deprecation warnings with ``httpauth`` tasks
+
+
+v 0.8.11 on Sep 26, 2019
+------------------------
+
+* Don't add an extra slash when redirecting to a domain in ``redirect_domains``
+
 
 v 0.8.10 on Sep 6, 2019
 -----------------------

--- a/tasks/http_auth.yml
+++ b/tasks/http_auth.yml
@@ -1,12 +1,19 @@
 ---
 - name: install apache2-utils and passlib
-  apt: name={{ item }}
-       state=present
-  with_items:
-    - apache2-utils
-    - python-passlib
+  apt:
+    name:
+      - apache2-utils
+      - python-passlib
+    state: present
 
 - name: add logins and passwords to htpasswd file
-  htpasswd: path={{ auth_file }} name={{ item.login }} password={{ item.password }} crypt_scheme=des_crypt
-            state=present owner=root group=www-data mode=640
+  htpasswd:
+    path: "{{ auth_file }}"
+    name: "{{ item.login }}"
+    password: "{{ item.password }}"
+    crypt_scheme: des_crypt
+    state: present
+    owner: root
+    group: www-data
+    mode: 640
   with_items: "{{ http_auth }}"

--- a/tasks/http_auth.yml
+++ b/tasks/http_auth.yml
@@ -15,5 +15,5 @@
     state: present
     owner: root
     group: www-data
-    mode: 640
+    mode: "640"
   with_items: "{{ http_auth }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,13 +70,13 @@
     - reload nginx
 
 - include: http_auth.yml
-  when: http_auth|bool
+  when: http_auth | default([]) | length > 0
 
 - name: remove htpasswd file
   file:
     path: "{{ auth_file }}"
     state: absent
-  when: not http_auth|bool
+  when: not http_auth | default([]) | length > 0
 
 - name: configure nginx server for our project
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,11 +70,13 @@
     - reload nginx
 
 - include: http_auth.yml
-  when: http_auth
+  when: http_auth|bool
 
 - name: remove htpasswd file
-  file: path={{ auth_file }} state=absent
-  when: not http_auth
+  file:
+    path: "{{ auth_file }}"
+    state: absent
+  when: not http_auth|bool
 
 - name: configure nginx server for our project
   template:


### PR DESCRIPTION
* Don't evaluate ``http_auth`` as bare variable
* Remove the loop from apt install to fix deprecation warning